### PR TITLE
improve ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:     [ubuntu-20.04]
+        os:     [ubuntu-20.04, ubuntu-22.04]
         mode:   [newlib, linux, musl]
         target: [rv32gc-ilp32d, rv64gc-lp64d]
         compiler: [gcc, llvm]
@@ -24,6 +24,8 @@ jobs:
             target: rv32gc-ilp32d
           - mode: musl
             compiler: llvm
+          - os: ubuntu-22.04
+            compiler: gcc
     steps:
       - name: Remove unneeded frameworks to recover disk space
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,15 +1,7 @@
 name: Build
 
-on:
-  push:
-    branches:
-      - master
-      - dev
-  pull_request:
-    branches:
-      - master
-      - dev
-
+on: [push, pull_request]
+    
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
ci turns out to pass except for the single exception of ubuntu-22.04+gcc combo, so i added ubuntu-22.04 back with an exception rule in build.yaml

also removed the "branches:" part from the "on:" rule so that ci runs simply for the branch having been pushed on 

